### PR TITLE
feat(Feat/change-select-for-typeorm): Change it to select only the columns that exist in the DB

### DIFF
--- a/src/common/graphql/customExtended.ts
+++ b/src/common/graphql/customExtended.ts
@@ -69,7 +69,7 @@ export class ExtendedRepository<T = unknown> extends Repository<T> {
     }
 
     const queryCondition = gqlQuery
-      ? getConditionFromGqlQuery<T>(gqlQuery, true)
+      ? getConditionFromGqlQuery.call(this, gqlQuery, true)
       : { relations: undefined, select: undefined };
 
     const condition: FindManyOptions<T> = {
@@ -101,7 +101,7 @@ export class ExtendedRepository<T = unknown> extends Repository<T> {
     gqlQuery?: string,
   ): Promise<T> {
     const queryCondition = gqlQuery
-      ? getConditionFromGqlQuery<T>(gqlQuery)
+      ? getConditionFromGqlQuery.call(this, gqlQuery)
       : { relations: undefined, select: undefined };
 
     const condition: FindOneOptions<T> = {

--- a/src/common/graphql/utils/getConditionFromGqlQuery.ts
+++ b/src/common/graphql/utils/getConditionFromGqlQuery.ts
@@ -1,5 +1,6 @@
 import { parse, print } from 'graphql';
 import { set } from 'lodash';
+import { Repository } from 'typeorm';
 
 import { AddKeyValueInObjectProps, GetInfoFromQueryProps } from './types';
 
@@ -32,10 +33,11 @@ const addKeyValuesInObject = <Entity>({
   return { relations, select };
 };
 
-export const getConditionFromGqlQuery = <Entity>(
+export function getConditionFromGqlQuery<Entity>(
+  this: Repository<Entity>,
   query: string,
   hasCountType?: boolean,
-): GetInfoFromQueryProps<Entity> => {
+): GetInfoFromQueryProps<Entity> {
   const ast = parse(query);
   const operationJson = print(ast);
 
@@ -52,12 +54,21 @@ export const getConditionFromGqlQuery = <Entity>(
   const stack = [];
 
   const regex = /[\s\{]/g;
+  let lastMetadata = this.metadata;
 
   return splitted.reduce(
     (acc, line) => {
       const replacedLine = line.replace(regex, '');
+
       if (line.includes('{')) {
         stack.push(replacedLine);
+        const isFirstLineDataType = hasCountType && replacedLine === DATA;
+
+        if (!isFirstLineDataType) {
+          lastMetadata = lastMetadata.relations.find(
+            (v) => v.propertyName === replacedLine,
+          ).inverseEntityMetadata;
+        }
 
         return addKeyValuesInObject({
           stack,
@@ -67,13 +78,33 @@ export const getConditionFromGqlQuery = <Entity>(
           hasCountType,
         });
       } else if (line.includes('}')) {
+        const hasDataTypeInStack =
+          hasCountType && stack.length && stack[0] === DATA;
+
+        lastMetadata =
+          stack.length < (hasDataTypeInStack ? 3 : 2)
+            ? this.metadata
+            : lastMetadata.relations.find(
+                (v) => v.propertyName === stack[stack.length - 2],
+              ).inverseEntityMetadata;
+
         stack.pop();
 
         return acc;
       }
 
+      const addedStack = [...stack, replacedLine];
+
+      if (
+        ![...lastMetadata.columns, ...lastMetadata.relations]
+          .map((v) => v.propertyName)
+          .includes(addedStack[addedStack.length - 1])
+      ) {
+        return acc;
+      }
+
       return addKeyValuesInObject({
-        stack: [...stack, replacedLine],
+        stack: addedStack,
         relations: acc.relations,
         select: acc.select,
         hasCountType,
@@ -84,4 +115,4 @@ export const getConditionFromGqlQuery = <Entity>(
       select: {},
     },
   );
-};
+}


### PR DESCRIPTION
#24 

I have modified the query to select only those columns that exist in the database, by checking the entity's metadata.