### PR TITLE
fix: CustomCacheInterceptor not returning cached value

### DIFF
--- a/src/cache/custom-cache.interceptor.ts
+++ b/src/cache/custom-cache.interceptor.ts
@@ -55,7 +55,6 @@ export class CustomCacheInterceptor implements NestInterceptor {
 
   private getArgs(context: ExecutionContext): unknown[] {
     const ctx = GqlExecutionContext.create(context);
-    const req = ctx.getContext().req;
-    return req.body;
+    return Object.values(ctx.getArgs());
   }
 }

--- a/src/cache/custom-cache.service.ts
+++ b/src/cache/custom-cache.service.ts
@@ -44,7 +44,7 @@ export class CustomCacheService {
       const methodOverride = async (...args: unknown[]) => {
         const result = async () => await methodRef.apply(instance, args);
 
-        return this.getOrSetCache({ customKey, options, result, args });
+        return this.getOrSetCache(customKey, args, options, result);
       };
 
       Object.defineProperty(instance, methodName, {
@@ -75,17 +75,12 @@ export class CustomCacheService {
     return customKey + JSON.stringify(args);
   }
 
-  async getOrSetCache({
-    options,
-    args,
-    result: _result,
-    customKey,
-  }: {
-    options: CustomCacheOptions;
-    args: unknown[];
-    result: () => Promise<unknown>;
-    customKey: string;
-  }) {
+  async getOrSetCache(
+    customKey: string,
+    args: unknown[],
+    options: CustomCacheOptions,
+    resultFn: () => Promise<unknown>,
+  ) {
     const { key: cacheKey = customKey, ttl = Infinity, logger } = options;
     const argsAddedKey = this.buildCacheKey(cacheKey, args);
 
@@ -94,7 +89,7 @@ export class CustomCacheService {
       return cachedValue;
     }
 
-    const result = await _result();
+    const result = await resultFn();
     await this.setCache(argsAddedKey, result, ttl, logger);
 
     return result;

--- a/src/cache/custom-cache.service.ts
+++ b/src/cache/custom-cache.service.ts
@@ -44,7 +44,7 @@ export class CustomCacheService {
       const methodOverride = async (...args: unknown[]) => {
         const result = async () => await methodRef.apply(instance, args);
 
-        return this.setCache({ customKey, options, result, args });
+        return this.getOrSetCache({ customKey, options, result, args });
       };
 
       Object.defineProperty(instance, methodName, {
@@ -53,7 +53,29 @@ export class CustomCacheService {
     };
   }
 
-  async setCache({
+  async getCache(key: string, logger?: CustomCacheOptions['logger']) {
+    const cached = await this.cacheManager.get(key);
+    if (cached !== undefined) {
+      logger?.('Cache Hit', { cacheKey: key });
+    }
+    return cached;
+  }
+
+  async setCache(
+    key: string,
+    data: unknown,
+    ttl: number = Infinity,
+    logger?: CustomCacheOptions['logger'],
+  ) {
+    await this.cacheManager.set(key, data, ttl);
+    logger?.('Cached', { cacheKey: key });
+  }
+
+  buildCacheKey(customKey: string, args: unknown[]) {
+    return customKey + JSON.stringify(args);
+  }
+
+  async getOrSetCache({
     options,
     args,
     result: _result,
@@ -65,20 +87,15 @@ export class CustomCacheService {
     customKey: string;
   }) {
     const { key: cacheKey = customKey, ttl = Infinity, logger } = options;
+    const argsAddedKey = this.buildCacheKey(cacheKey, args);
 
-    const argsAddedKey = cacheKey + JSON.stringify(args);
-
-    const cachedValue = await this.cacheManager.get(argsAddedKey);
-    if (Boolean(cachedValue)) {
-      logger?.('Cache Hit', { cacheKey });
-
+    const cachedValue = await this.getCache(argsAddedKey, logger);
+    if (cachedValue !== undefined) {
       return cachedValue;
     }
 
     const result = await _result();
-
-    await this.cacheManager.set(argsAddedKey, result, ttl);
-    logger?.('Cached', { cacheKey });
+    await this.setCache(argsAddedKey, result, ttl, logger);
 
     return result;
   }


### PR DESCRIPTION
## Summary
  - Fix bug where handler was re-executed even on cache hit
  - Refactor interceptor to RxJS style (switchMap)
  - Fix `getArgs()` to use `ctx.getArgs()` instead of `req.body`

  ## Changes
  - `CustomCacheInterceptor`: Handle cache hit/miss branching with RxJS `switchMap`
  - `CustomCacheService`: Extract `getCache`, `setCache`, `buildCacheKey` methods