### PR TITLE
fix: handle HttpException properly in GraphQL error formatter

### DIFF
--- a/src/common/exceptions/exception.constant.ts
+++ b/src/common/exceptions/exception.constant.ts
@@ -10,6 +10,7 @@ export const GRAPHQL_ERROR_CODES = [
 ];
 
 export const PRESERVED_STATUS_CODES = [
+  HttpStatus.BAD_REQUEST,
   HttpStatus.UNAUTHORIZED,
   HttpStatus.FORBIDDEN,
 ] as const;

--- a/src/common/exceptions/exception.factory.ts
+++ b/src/common/exceptions/exception.factory.ts
@@ -31,9 +31,8 @@ export const createException = () => {
       constructor(arg?: ExceptionParams<K>) {
         super(statusCode, defaultMessage, code);
 
-        if (arg) {
-          this.message = composeExceptionMessage(defaultMessage, arg) as K;
-        }
+        const composed = composeExceptionMessage(defaultMessage, arg ?? {});
+        this.message = (composed || code) as K;
       }
     };
   };

--- a/src/common/exceptions/exception.format.ts
+++ b/src/common/exceptions/exception.format.ts
@@ -4,6 +4,7 @@ import { GraphQLError } from 'graphql';
 
 import { PRESERVED_STATUS_CODES } from './exception.constant';
 import {
+  getHttpExceptionCode,
   isBaseException,
   isGraphqlOriginalError,
   isHttpException,
@@ -23,6 +24,14 @@ const determineErrorCondition = (error: GraphQLError) => {
     return {
       errorStatus: error.originalError.statusCode,
       errorCode: error.originalError.code,
+    };
+  }
+
+  if (isHttpException(error.originalError)) {
+    const status = error.originalError.getStatus();
+    return {
+      errorStatus: status,
+      errorCode: getHttpExceptionCode(status),
     };
   }
 

--- a/src/common/exceptions/exception.format.ts
+++ b/src/common/exceptions/exception.format.ts
@@ -5,6 +5,7 @@ import { GraphQLError } from 'graphql';
 import { PRESERVED_STATUS_CODES } from './exception.constant';
 import {
   getHttpExceptionCode,
+  getHttpExceptionMessage,
   isBaseException,
   isGraphqlOriginalError,
   isHttpException,
@@ -84,6 +85,14 @@ const handleInternalServerError = (
   }
 };
 
+const determineErrorMessage = (error: GraphQLError): string => {
+  if (isHttpException(error.originalError)) {
+    return getHttpExceptionMessage(error.originalError);
+  }
+
+  return error.message;
+};
+
 const formatError = (
   error: GraphQLError,
   options: {
@@ -104,7 +113,7 @@ const formatError = (
   options.setHttpStatus(httpStatus);
 
   return {
-    message: error.message,
+    message: determineErrorMessage(error),
     locations: error.locations,
     path: error.path,
     extensions: {

--- a/src/common/exceptions/exception.util.ts
+++ b/src/common/exceptions/exception.util.ts
@@ -27,3 +27,25 @@ export const isHttpException = (error: unknown): error is HttpException => {
 export const getHttpExceptionCode = (status: number): string => {
   return HttpStatus[status] || 'HTTP_ERROR';
 };
+
+export const getHttpExceptionMessage = (error: HttpException): string => {
+  const response = error.getResponse();
+
+  if (typeof response === 'string') {
+    return response;
+  }
+
+  if (typeof response === 'object' && response !== null) {
+    const { message } = response as { message?: string | string[] };
+
+    if (Array.isArray(message)) {
+      return message.join(', ');
+    }
+
+    if (typeof message === 'string') {
+      return message;
+    }
+  }
+
+  return error.message;
+};

--- a/src/common/exceptions/exception.util.ts
+++ b/src/common/exceptions/exception.util.ts
@@ -1,4 +1,4 @@
-import { HttpException } from '@nestjs/common';
+import { HttpException, HttpStatus } from '@nestjs/common';
 
 import { GraphQLErrorExtensions } from 'graphql';
 
@@ -22,4 +22,8 @@ export const isBaseException = (
 
 export const isHttpException = (error: unknown): error is HttpException => {
   return error instanceof HttpException;
+};
+
+export const getHttpExceptionCode = (status: number): string => {
+  return HttpStatus[status] || 'HTTP_ERROR';
 };


### PR DESCRIPTION
  ## Summary
  - Fix HttpException (e.g., ValidationPipe errors) being incorrectly treated as 500 INTERNAL_SERVER_ERROR
  - Extract actual validation messages from HttpException response

  ## Changes
  - Add HttpException handling branch in `determineErrorCondition`
  - Add BAD_REQUEST to `PRESERVED_STATUS_CODES`
  - Add `getHttpExceptionMessage` to extract validation error messages
  - Add `determineErrorMessage` to format error messages correctly

  ## Before
  ```json
  {
    "message": "Bad Request Exception",
    "extensions": { "errorStatus": 500, "errorCode": "INTERNAL_SERVER_ERROR" }
  }

  After

  {
    "message": "username should not be empty",
    "extensions": { "errorStatus": 400, "errorCode": "BAD_REQUEST" }
  }